### PR TITLE
fix: force dynamic cv route

### DIFF
--- a/app/api/cv/route.ts
+++ b/app/api/cv/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(_request: Request) {
+  return NextResponse.json({ message: 'CV route active' });
+}


### PR DESCRIPTION
## Summary
- mark CV API route as force-dynamic to avoid StaticGenBailoutError for POST requests

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build` (fails: Failed to fetch `Inter` font from Google Fonts)


------
https://chatgpt.com/codex/tasks/task_e_689a4effdcd8832fae1323e53d0bd34e